### PR TITLE
Fix delay in alarms after OS sleep/hibernation

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -54,6 +54,16 @@ function init() {
         .then((obj) => {
             if (obj.hasOwnProperty(CHECK_TIME_STARTUP_ONLY_KEY)) { // This may not be necessary
                 if (!obj[CHECK_TIME_STARTUP_ONLY_KEY].check) {
+                    // Every time the window is focused, check the time and reset the alarms.
+                    // This prevents any delay in the alarms after OS sleep/hibernation.
+                    browser.windows.onFocusChanged.addListener((windowId) => {
+                        if (windowId !== browser.windows.WINDOW_ID_NONE) {
+                            checkTime();
+                            browser.alarms.clearAll();
+                            createDailyAlarm(SUNRISE_TIME_KEY, NEXT_SUNRISE_ALARM_NAME),
+                            createDailyAlarm(SUNSET_TIME_KEY, NEXT_SUNSET_ALARM_NAME)
+                        }
+                    });
                     return Promise.all([
                             createDailyAlarm(SUNRISE_TIME_KEY, NEXT_SUNRISE_ALARM_NAME),
                             createDailyAlarm(SUNSET_TIME_KEY, NEXT_SUNSET_ALARM_NAME)


### PR DESCRIPTION
Any sleep/hibernation currently messes up the schedule. If my laptop goes into sleep for two hours, the next theme change will be delayed by two hours. Since I usually keep Firefox running for days and just close the laptop when I don't use it, with this extension I get the theme changing at basically random times.

This fix just reschedules the alarms at every `windows.onFocusChanged` event. It's not completely fail proof, as waking up the computer doesn't by itself trigger a `onFocusChanged` event, so I'm not sure this is the right solution. The older versions of the extension, which checked the time every N minutes, were good for me. With this approach the timing is more accurate, but I would be fine with any fix.