### PR TITLE
Fixed System Theme Detection doesn't work in Firefox #43

### DIFF
--- a/js/system-theme-notifier.js
+++ b/js/system-theme-notifier.js
@@ -1,0 +1,30 @@
+(async () => {
+    while( true) {
+        try {
+            console.log("automaticDark: sending message")
+            // on startup: send message to extension
+            await browser.runtime.sendMessage({
+                type: "color-scheme-change",
+                tab: document.location.href,
+                prefersColorScheme: window.matchMedia('(prefers-color-scheme: dark)').matches
+            });
+
+            break; // recieving end has started listening, message delivered!
+        } catch (err) {
+            console.log("automaticDark: error, retrying in 200ms ", err)
+            await new Promise((resolve) => setTimeout(resolve, 200)); // pause, then try again
+        }
+    }
+
+    console.log("automaticDark: inithandler")
+    // then repeat on every change
+    // Add listener that will change the theme if the mode is set to "system-theme"
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', ({matches}) => {
+        console.log("automaticDark: changed!")
+        browser.runtime.sendMessage({
+            type: "color-scheme-change",
+            tab: document.location.href,
+            prefersColorScheme: matches
+        });
+    });
+})()

--- a/manifest.json
+++ b/manifest.json
@@ -20,12 +20,20 @@
     "browserSettings",
     "management",
     "storage",
-    "theme"
+    "theme",
+    "<all_urls>"
   ],
 
   "background": {
     "scripts": ["js/utils.js", "js/common.js", "js/background.js", "lib/suncalc.js"]
   },
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["js/system-theme-notifier.js"]
+    }
+  ],
 
   "options_ui": {
       "page": "html/options.html",


### PR DESCRIPTION
This introduced a few changes in the architecture.

Essentially, a script is attatched to every tab, to listen for the changes in the (prefers-color-scheme: dark) media query.
Upon change, the extention is messaged.

This sets a global variable, that is then used to update the theme, either immediately, or when you focus the window
