### PR TITLE
Fix most theme switching bugs: alarm crash, dead system-theme events, stale theme overlay.

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -6,8 +6,11 @@ browser.runtime.onInstalled.addListener(async ({reason, previousVersion}) => {
   if (DEBUG_MODE)
     console.log("automaticDark DEBUG: 0 - Installed - Reason: " + reason + ", Previous Version: " + previousVersion + ".");
 
-  init();
-  
+  // No init() here: the background page just loaded, so the top-level
+  // init() above already ran. A second call registers the anonymous
+  // matchMedia/focus listeners twice, and every scheme-change event
+  // then runs two concurrent theme-switch chains.
+
   if (reason === 'install') {
     if (DEBUG_MODE)
       console.log("automaticDark DEBUG: 0 - Open the options page.");

--- a/js/common.js
+++ b/js/common.js
@@ -380,7 +380,8 @@ function enableTheme(theme, themeKey) {
                 if (DEBUG_MODE)
                     console.log("automaticDark DEBUG: 100 enableTheme - Enabled theme " + theme.themeId);
                 detect_scheme_change_block = true; // Temporarily disables detection of color scheme change
-                browser.management.setEnabled(theme.themeId, true).then(enableSchemeChangeDetection);
+                browser.management.setEnabled(theme.themeId, true).then(enableSchemeChangeDetection,
+                    (err) => { detect_scheme_change_block = false; onError(err); });
             }
             else {
                 if (DEBUG_MODE)
@@ -399,43 +400,54 @@ function enableSchemeChangeDetection() {
         .then((obj) => {
             let mode = obj[CHANGE_MODE_KEY].mode;
 
-            browser.theme.getCurrent().then(current_theme => {
+            // Only modify the current theme when the extension is set to "system theme" mode.
+            if (mode === "system-theme") {
+                // Drop any dynamic theme we previously applied via theme.update()
+                // BEFORE reading getCurrent(). theme.update() creates an overlay
+                // owned by this extension that sits on top of the enabled static
+                // theme; while that overlay exists, getCurrent() returns it, not
+                // the static theme underneath.
+                // Without the reset, a stale overlay (e.g. last night's dark
+                // colors) gets re-applied over the newly enabled theme and masks
+                // it indefinitely, even though management reports the right theme.
+                browser.theme.reset()
+                    .then(() => browser.theme.getCurrent())
+                    .then((current_theme) => {
+                        if (DEBUG_MODE)
+                            console.log(current_theme);
 
+                        if (current_theme.colors) { // "System theme — auto" is an empty object
+                            if (DEBUG_MODE)
+                                console.log("automaticDark DEBUG: enableSchemeChangeDetection - Mode is set to 'system-theme'. Set color_scheme to system.");
+
+                            // Some themes are returned without a 'properties' object.
+                            // Guard against that so we don't throw and leave the
+                            // scheme-change block stuck on (silently disabling detection).
+                            if (!current_theme.properties)
+                                current_theme.properties = {};
+                            current_theme.properties.color_scheme = "system"; // Change the property of the theme object
+                            current_theme.properties.content_color_scheme = "system"; // Optional
+
+                            return browser.theme.update(current_theme).then(() => {
+                                if (DEBUG_MODE)
+                                    console.log("automaticDark DEBUG: enableSchemeChangeDetection - Updated current theme.");
+                            });
+                        }
+                    })
+                    // Un-block scheme change detection whether or not the update applied.
+                    .then(() => { detect_scheme_change_block = false; },
+                          (err) => { detect_scheme_change_block = false; onError(err); });
+            }
+            else { //if (mode === "location-suntimes" || mode === "manual-suntimes"){
                 if (DEBUG_MODE)
-                    console.log(current_theme);
+                    console.log("automaticDark DEBUG: enableSchemeChangeDetection - Mode is set to: " + mode + ". Reset theme to default.");
 
-                if (current_theme.colors) { // "System theme — auto" is an empty object
-
-                    // Only modify the current theme when the extension is set to "system theme" mode.
-                    if (mode === "system-theme") {
-                        if (DEBUG_MODE)
-                            console.log("automaticDark DEBUG: enableSchemeChangeDetection - Mode is set to 'system-theme'. Set color_scheme to system.");
-
-                        current_theme.properties.color_scheme = "system"; // Change the property of the theme object
-                        current_theme.properties.content_color_scheme = "system"; // Optional
-
-                        browser.theme.update(current_theme).then(() => {
-                            if (DEBUG_MODE)
-                                console.log("automaticDark DEBUG: enableSchemeChangeDetection - Updated current theme.");
-                            detect_scheme_change_block = false;
-                        }); // Applies amended theme and un-block scheme change detection
-
-                    }
-                    else { //if (mode === "location-suntimes" || mode === "manual-suntimes"){
-                        if (DEBUG_MODE)
-                            console.log("automaticDark DEBUG: enableSchemeChangeDetection - Mode is set to: " + mode + ". Reset theme to default.");
-
-                        browser.theme.reset().then(() => {
-                            if (DEBUG_MODE)
-                                console.log("automaticDark DEBUG: enableSchemeChangeDetection - Reset current theme.");
-                            detect_scheme_change_block = false;
-                        });
-                    }
-
-                } else {
+                browser.theme.reset().then(() => {
+                    if (DEBUG_MODE)
+                        console.log("automaticDark DEBUG: enableSchemeChangeDetection - Reset current theme.");
                     detect_scheme_change_block = false;
-                }
-            });
+                });
+            }
         });
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -14,6 +14,7 @@ const SUNRISE_TIME_KEY = KEY_PREFIX + "sunriseTime";
 const SUNSET_TIME_KEY = KEY_PREFIX + "sunsetTime";
 const NEXT_SUNRISE_ALARM_NAME = KEY_PREFIX + "nextSunrise";
 const NEXT_SUNSET_ALARM_NAME = KEY_PREFIX + "nextSunset";
+const SYSTEM_THEME_POLL_ALARM_NAME = KEY_PREFIX + "systemThemePoll";
 
 const GEOLOCATION_LATITUDE_KEY = KEY_PREFIX + "geoLatitude";
 const GEOLOCATION_LONGITUDE_KEY = KEY_PREFIX + "geoLongitude";
@@ -81,6 +82,15 @@ function init() {
                 // On start up, change the themes appropriately.
                 changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode);
 
+                // Poll the system theme on a timer as a fallback. Since Firefox 95,
+                // prefers-color-scheme in extension pages reflects the browser theme
+                // rather than the OS (Bugzilla 1741009, resolved WORKSFORME), so the
+                // matchMedia 'change' event below only fires on OS theme changes while
+                // the color_scheme "system" workaround is applied — and a change can
+                // still be missed (e.g. while the machine sleeps).
+                // See issues #43, #64, #67.
+                browser.alarms.create(SYSTEM_THEME_POLL_ALARM_NAME, {periodInMinutes: 1});
+
                 // Add a listener to change the theme when the window is focused.
 
                 // For changing based on system theme, this is an additional check as
@@ -103,6 +113,9 @@ function init() {
                                     createAlarm(SUNRISE_TIME_KEY, NEXT_SUNRISE_ALARM_NAME, 60 * 24),
                                     createAlarm(SUNSET_TIME_KEY, NEXT_SUNSET_ALARM_NAME, 60 * 24)
                                 }
+
+                                // clearAll() above can wipe the poll alarm; re-establish it.
+                                browser.alarms.create(SYSTEM_THEME_POLL_ALARM_NAME, {periodInMinutes: 1});
                             });
                     }
                 });
@@ -241,6 +254,16 @@ function alarmListener(alarmInfo) {
             // checkTime() reads the (possibly just-updated) sunrise/sunset times,
             // enables the correct day/night theme, and records the current mode.
             .then(() => checkTime());
+    }
+    else if (alarmInfo.name === SYSTEM_THEME_POLL_ALARM_NAME) {
+        // System-theme mode: re-check the OS theme on a timer, as a fallback
+        // for when the prefers-color-scheme 'change' event isn't delivered.
+        return browser.storage.local.get(CHANGE_MODE_KEY)
+            .then((obj) => {
+                if (obj[CHANGE_MODE_KEY].mode === "system-theme") {
+                    return checkSysTheme();
+                }
+            }, onError);
     }
     else if (alarmInfo.name === "checkTime") {
         return checkTime();

--- a/js/common.js
+++ b/js/common.js
@@ -201,9 +201,16 @@ function init() {
                     ]);
                 }
             }
-        }, onError)
-        .then((obj) => {
+            else {
+                // Startup-only mode queues no switch chain (which would apply
+                // the color_scheme workaround itself), so apply the workaround
+                // to whatever theme is painted now. Running this when a chain
+                // WAS queued above would strip the workaround that chain just
+                // applied: enableSchemeChangeDetection() starts with
+                // theme.reset(), which repaints the default theme
+                // (bug 1415267).
             return queueThemeSwitch(enableSchemeChangeDetection);
+            }
         }, onError);
 }
 
@@ -403,26 +410,72 @@ function enableTheme(theme, themeKey) {
             else {
                 if (DEBUG_MODE)
                     console.log("automaticDark DEBUG: 100 enableTheme - " + theme.themeId + " is already enabled.");
-                return reapplyColorSchemeFix();
+                return reapplyColorSchemeFix(theme.themeId);
             }
         }, onError);
 }
+
+// Built-in themes report no colors from theme.getCurrent(), so for them a
+// colorless paint cannot be told apart from a correct one.
+const BUILT_IN_THEME_IDS = [
+    "default-theme@mozilla.org",
+    "firefox-compact-light@mozilla.org",
+    "firefox-compact-dark@mozilla.org"
+];
+
+// If re-enabling a theme doesn't surface colors, the theme genuinely has
+// none (like the built-ins above, should their ids ever change) — remember
+// it and stop retrying, or the once-a-minute poll would toggle it into a
+// visible flicker loop.
+let repaint_attempted_theme = null;
 
 // Re-apply the color_scheme fix if the enabled theme is missing it.
 // Switching to system-theme mode while the matching theme is already
 // enabled skips enableSchemeChangeDetection(), leaving the theme without
 // color_scheme "system" — OS scheme changes then go undetected for the
 // rest of the session.
-function reapplyColorSchemeFix() {
+function reapplyColorSchemeFix(themeId) {
     return browser.storage.local.get(CHANGE_MODE_KEY)
         .then((obj) => {
             if (obj[CHANGE_MODE_KEY].mode !== "system-theme") {
                 return;
             }
             return browser.theme.getCurrent().then((current_theme) => {
-                if (current_theme.colors
-                        && (!current_theme.properties || current_theme.properties.color_scheme !== "system")) {
+                if (current_theme.colors) {
+                    // A painted theme has colors, so any earlier repaint
+                    // attempt worked; allow future repaints again.
+                    repaint_attempted_theme = null;
+                    if (!current_theme.properties || current_theme.properties.color_scheme !== "system") {
                     return enableSchemeChangeDetection();
+                }
+                    return;
+                }
+                // management can report the theme as enabled while the default
+                // theme is what is actually painted: theme.reset() always
+                // repaints the default theme (bug 1415267), and reloading the
+                // extension drops its theme.update() overlay the same way.
+                // getCurrent() then reports no colors, so the branch above
+                // never fires and the wrong paint would otherwise be permanent.
+                // Toggle the theme to force a real repaint.
+                if (themeId
+                    && !BUILT_IN_THEME_IDS.includes(themeId)
+                    && themeId !== repaint_attempted_theme) {
+                    if (DEBUG_MODE)
+                        console.log("automaticDark DEBUG: reapplyColorSchemeFix - " + themeId + " is enabled but not painted. Re-enabling it.");
+                    repaint_attempted_theme = themeId;
+                    detect_scheme_change_block = true;
+                    return browser.management.setEnabled(themeId, false)
+                        .then(() => browser.management.setEnabled(themeId, true))
+                        .then(enableSchemeChangeDetection,
+                            (err) => { detect_scheme_change_block = false; onError(err); })
+                        .then(() => browser.theme.getCurrent())
+                        .then((repainted) => {
+                            // Colors surfacing means the repaint worked; allow
+                            // another repaint if the paint is lost again later.
+                            if (repainted.colors) {
+                                repaint_attempted_theme = null;
+                            }
+                        });
                 }
             });
         });

--- a/js/common.js
+++ b/js/common.js
@@ -300,9 +300,6 @@ function alarmListener(alarmInfo) {
                 }
             }, onError);
     }
-    else if (alarmInfo.name === "checkTime") {
-        return queueThemeSwitch(checkTime);
-    }
 }
 
 // Check the current system time and set the theme based on the time.

--- a/js/common.js
+++ b/js/common.js
@@ -386,8 +386,29 @@ function enableTheme(theme, themeKey) {
             else {
                 if (DEBUG_MODE)
                     console.log("automaticDark DEBUG: 100 enableTheme - " + theme.themeId + " is already enabled.");
+                return reapplyColorSchemeFix();
             }
         }, onError);
+}
+
+// Re-apply the color_scheme fix if the enabled theme is missing it.
+// Switching to system-theme mode while the matching theme is already
+// enabled skips enableSchemeChangeDetection(), leaving the theme without
+// color_scheme "system" — OS scheme changes then go undetected for the
+// rest of the session.
+function reapplyColorSchemeFix() {
+    return browser.storage.local.get(CHANGE_MODE_KEY)
+        .then((obj) => {
+            if (obj[CHANGE_MODE_KEY].mode !== "system-theme") {
+                return;
+            }
+            return browser.theme.getCurrent().then((current_theme) => {
+                if (current_theme.colors
+                        && (!current_theme.properties || current_theme.properties.color_scheme !== "system")) {
+                    enableSchemeChangeDetection();
+                }
+            });
+        });
 }
 
 // Modifies the color scheme of the current theme to prevent interference with detection of the OS system theme.

--- a/js/common.js
+++ b/js/common.js
@@ -217,56 +217,30 @@ function alarmListener(alarmInfo) {
     if (DEBUG_MODE)
         console.log("automaticDark DEBUG: Start alarmListener");
 
-    if (alarmInfo.name === NEXT_SUNRISE_ALARM_NAME) {
-        return browser.storage.local.get([CHANGE_MODE, DAYTIME_THEME_KEY])
-            .then(
-                (values) => {
-                    // If we are set to get suntimes automatically,
-                    // then calculate the sunset again upon
-                    // an alarm and create new alarms based on that.
-                    if (obj[CHANGE_MODE_KEY] = "location-suntimes") {
-                        calculateSuntimes()
-                            .then((result) => {
-                                return Promise.all([
-                                    browser.storage.local.set({[SUNRISE_TIME_KEY]: {time: convertDateToString(result.nextSunrise)}}),
-                                    browser.storage.local.set({[SUNSET_TIME_KEY]: {time: convertDateToString(result.nextSunset)}})
-                                ]);
-                            })
-                            .then(() => {
-                                return Promise.all([
-                                    createAlarm(SUNRISE_TIME_KEY, NEXT_SUNRISE_ALARM_NAME, 60 * 24),
-                                    createAlarm(SUNSET_TIME_KEY, NEXT_SUNSET_ALARM_NAME, 60 * 24)
-                                ]);
-                            });
-
-                        
-                    }
-                    enableTheme(values, DAYTIME_THEME_KEY);
+    if (alarmInfo.name === NEXT_SUNRISE_ALARM_NAME || alarmInfo.name === NEXT_SUNSET_ALARM_NAME) {
+        return browser.storage.local.get(CHANGE_MODE_KEY)
+            .then((obj) => {
+                // In automatic (location) mode, recalculate the next sunrise/sunset
+                // times upon each alarm and reschedule the alarms based on them.
+                if (obj[CHANGE_MODE_KEY].mode === "location-suntimes") {
+                    return calculateSuntimes()
+                        .then((result) => {
+                            return Promise.all([
+                                browser.storage.local.set({[SUNRISE_TIME_KEY]: {time: convertDateToString(result.nextSunrise)}}),
+                                browser.storage.local.set({[SUNSET_TIME_KEY]: {time: convertDateToString(result.nextSunset)}})
+                            ]);
+                        })
+                        .then(() => {
+                            return Promise.all([
+                                createAlarm(SUNRISE_TIME_KEY, NEXT_SUNRISE_ALARM_NAME, 60 * 24),
+                                createAlarm(SUNSET_TIME_KEY, NEXT_SUNSET_ALARM_NAME, 60 * 24)
+                            ]);
+                        });
                 }
-                , onError);
-    }
-    else if (alarmInfo.name === NEXT_SUNSET_ALARM_NAME) {
-        return browser.storage.local.get([AUTOMATIC_SUNTIMES_KEY, NIGHTTIME_THEME_KEY])
-            .then(
-                (values) => {
-                    if (obj[CHANGE_MODE_KEY] = "location-suntimes") {
-                        calculateSuntimes()
-                            .then((result) => {
-                                return Promise.all([
-                                    browser.storage.local.set({[SUNRISE_TIME_KEY]: {time: convertDateToString(result.nextSunrise)}}),
-                                    browser.storage.local.set({[SUNSET_TIME_KEY]: {time: convertDateToString(result.nextSunset)}})
-                                ]);
-                            })
-                            .then(() => {
-                                return Promise.all([
-                                    createAlarm(SUNRISE_TIME_KEY, NEXT_SUNRISE_ALARM_NAME, 60 * 24),
-                                    createAlarm(SUNSET_TIME_KEY, NEXT_SUNSET_ALARM_NAME, 60 * 24)
-                                ]);
-                            });
-                    }
-                    enableTheme(values, NIGHTTIME_THEME_KEY);
-                }
-                , onError);
+            }, onError)
+            // checkTime() reads the (possibly just-updated) sunrise/sunset times,
+            // enables the correct day/night theme, and records the current mode.
+            .then(() => checkTime());
     }
     else if (alarmInfo.name === "checkTime") {
         return checkTime();

--- a/js/common.js
+++ b/js/common.js
@@ -288,6 +288,19 @@ function alarmListener(alarmInfo) {
 // Otherwise, set nighttime theme.
 
 // TODO: Can split this function to be more generic. Make function enableTime happen as a parameter.
+// Record the current mode (day-mode/night-mode), writing storage only
+// when the value actually changes. The once-a-minute poll and the
+// window-focus listener land here constantly; without the guard they
+// generate a steady stream of no-op writes and onChanged events.
+function setCurrentMode(mode) {
+    return browser.storage.local.get(CURRENT_MODE_KEY)
+        .then((obj) => {
+            if (!obj[CURRENT_MODE_KEY] || obj[CURRENT_MODE_KEY].mode !== mode) {
+                return browser.storage.local.set({[CURRENT_MODE_KEY]: {mode: mode}});
+            }
+        });
+}
+
 function checkTime() {
     let date = new Date(Date.now());
     let hours = date.getHours();
@@ -311,7 +324,7 @@ function checkTime() {
                     .then((obj) => {
                         return enableTheme(obj, DAYTIME_THEME_KEY)
                             .then(() => {
-                                return browser.storage.local.set({[CURRENT_MODE_KEY]: {mode: "day-mode"}});
+                                return setCurrentMode("day-mode");
                             });
                     }, onError);
             } else {
@@ -319,7 +332,7 @@ function checkTime() {
                     .then((obj) => {
                         return enableTheme(obj, NIGHTTIME_THEME_KEY)
                             .then(() => {
-                                return browser.storage.local.set({[CURRENT_MODE_KEY]: {mode: "night-mode"}});
+                                return setCurrentMode("night-mode");
                             });
                     }, onError);
             }
@@ -337,7 +350,7 @@ function checkSysTheme() {
         return browser.storage.local.get(NIGHTTIME_THEME_KEY)
             .then((obj) => {
                 return Promise.all([
-                    browser.storage.local.set({[CURRENT_MODE_KEY]: {mode: "night-mode"}}), 
+                    setCurrentMode("night-mode"),
                     enableTheme(obj, NIGHTTIME_THEME_KEY)
                 ]);
             }, onError);
@@ -347,7 +360,7 @@ function checkSysTheme() {
         return browser.storage.local.get(DAYTIME_THEME_KEY)
             .then((obj) => {
                 return Promise.all([
-                    browser.storage.local.set({[CURRENT_MODE_KEY]: {mode: "day-mode"}}),
+                    setCurrentMode("day-mode"),
                     enableTheme(obj, DAYTIME_THEME_KEY)
                 ]);
             }, onError);

--- a/js/common.js
+++ b/js/common.js
@@ -37,11 +37,24 @@ var detect_scheme_change_block = false; // This is just a sneaky way to prevent 
 let DEBUG_MODE = false;
 browser.storage.local.get(DEBUG_MODE_KEY)
     .then((obj) => {
-        DEBUG_MODE = obj[DEBUG_MODE_KEY].check;
+        // On a fresh install this read runs before init() has created
+        // the key, so guard against it being absent.
+        DEBUG_MODE = !!(obj[DEBUG_MODE_KEY] && obj[DEBUG_MODE_KEY].check);
 
         if (DEBUG_MODE)
             console.log("automaticDark DEBUG: DEBUG_MODE is enabled.");
     }, onError);
+
+// Pick up the Debug mode checkbox immediately. The read above only runs
+// once at page load, so the background page never saw later changes —
+// toggling the checkbox did nothing for its logging until the extension
+// reloaded or the browser restarted.
+browser.storage.onChanged.addListener((changes, area) => {
+    if (area === "local" && changes[DEBUG_MODE_KEY]) {
+        DEBUG_MODE = !!(changes[DEBUG_MODE_KEY].newValue && changes[DEBUG_MODE_KEY].newValue.check);
+        console.log("automaticDark DEBUG: DEBUG_MODE is now " + DEBUG_MODE + ".");
+    }
+});
 
 // Things to do when the extension is starting up
 // (or if the settings have been reset).

--- a/js/common.js
+++ b/js/common.js
@@ -202,14 +202,12 @@ function init() {
                 }
             }
             else {
-                // Startup-only mode queues no switch chain (which would apply
-                // the color_scheme workaround itself), so apply the workaround
-                // to whatever theme is painted now. Running this when a chain
-                // WAS queued above would strip the workaround that chain just
-                // applied: enableSchemeChangeDetection() starts with
-                // theme.reset(), which repaints the default theme
-                // (bug 1415267).
-            return queueThemeSwitch(enableSchemeChangeDetection);
+                // Change only on startup: this is the startup, so switch once.
+                // In system-theme mode the switch chain also applies the
+                // color_scheme workaround and re-enables a theme whose paint was
+                // lost (e.g. after an extension reload); the other modes need
+                // neither. Nothing further is needed here.
+                return queueThemeSwitch(() => changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode));
             }
         }, onError);
 }

--- a/js/common.js
+++ b/js/common.js
@@ -34,6 +34,23 @@ let DEFAULT_NIGHTTIME_THEME = "";
 
 var detect_scheme_change_block = false; // This is just a sneaky way to prevent flashing
 
+// All theme switches are funneled through this queue so only one runs at a
+// time. The change event, the focus listener, the poll and the startup check
+// can otherwise fire near-simultaneously and interleave: the second chain's
+// theme.reset() can land after the first chain's finished switch, and
+// theme.reset() always repaints the *default* theme, not the enabled one
+// (see bug 1415267) — leaving the default theme on screen with no
+// color_scheme workaround applied and nothing left to correct it.
+let theme_switch_queue = Promise.resolve();
+
+// Run fn after every previously queued theme switch has fully finished.
+// Returns fn's own promise; the stored queue tail never stays rejected.
+function queueThemeSwitch(fn) {
+    const result = theme_switch_queue.then(fn);
+    theme_switch_queue = result.then(() => {}, onError);
+    return result;
+}
+
 let DEBUG_MODE = false;
 browser.storage.local.get(DEBUG_MODE_KEY)
     .then((obj) => {
@@ -93,7 +110,7 @@ function init() {
         .then((obj) => {
             if (!obj[CHECK_TIME_STARTUP_ONLY_KEY].check) {
                 // On start up, change the themes appropriately.
-                changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode);
+                queueThemeSwitch(() => changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode));
 
                 // Poll the system theme on a timer as a fallback. Since Firefox 95,
                 // prefers-color-scheme in extension pages reflects the browser theme
@@ -119,7 +136,7 @@ function init() {
 
                         browser.storage.local.get(CHANGE_MODE_KEY)
                             .then((obj) => {
-                                changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode);
+                                queueThemeSwitch(() => changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode));
 
                                 if (obj[CHANGE_MODE_KEY].mode === "location-suntimes" || obj[CHANGE_MODE_KEY].mode === "manual-suntimes"){
                                     browser.alarms.clearAll();
@@ -143,7 +160,7 @@ function init() {
                         browser.storage.local.get(CHANGE_MODE_KEY)
                             .then((obj) => {
                                 if (obj[CHANGE_MODE_KEY].mode === "system-theme") {
-                                    checkSysTheme();
+                                    queueThemeSwitch(checkSysTheme);
                                 }
                         });
                     } else {
@@ -186,7 +203,7 @@ function init() {
             }
         }, onError)
         .then((obj) => {
-            enableSchemeChangeDetection();
+            return queueThemeSwitch(enableSchemeChangeDetection);
         }, onError);
 }
 
@@ -266,7 +283,7 @@ function alarmListener(alarmInfo) {
             }, onError)
             // checkTime() reads the (possibly just-updated) sunrise/sunset times,
             // enables the correct day/night theme, and records the current mode.
-            .then(() => checkTime());
+            .then(() => queueThemeSwitch(checkTime));
     }
     else if (alarmInfo.name === SYSTEM_THEME_POLL_ALARM_NAME) {
         // System-theme mode: re-check the OS theme on a timer, as a fallback
@@ -274,12 +291,12 @@ function alarmListener(alarmInfo) {
         return browser.storage.local.get(CHANGE_MODE_KEY)
             .then((obj) => {
                 if (obj[CHANGE_MODE_KEY].mode === "system-theme") {
-                    return checkSysTheme();
+                    return queueThemeSwitch(checkSysTheme);
                 }
             }, onError);
     }
     else if (alarmInfo.name === "checkTime") {
-        return checkTime();
+        return queueThemeSwitch(checkTime);
     }
 }
 
@@ -380,7 +397,7 @@ function enableTheme(theme, themeKey) {
                 if (DEBUG_MODE)
                     console.log("automaticDark DEBUG: 100 enableTheme - Enabled theme " + theme.themeId);
                 detect_scheme_change_block = true; // Temporarily disables detection of color scheme change
-                browser.management.setEnabled(theme.themeId, true).then(enableSchemeChangeDetection,
+                return browser.management.setEnabled(theme.themeId, true).then(enableSchemeChangeDetection,
                     (err) => { detect_scheme_change_block = false; onError(err); });
             }
             else {
@@ -405,7 +422,7 @@ function reapplyColorSchemeFix() {
             return browser.theme.getCurrent().then((current_theme) => {
                 if (current_theme.colors
                         && (!current_theme.properties || current_theme.properties.color_scheme !== "system")) {
-                    enableSchemeChangeDetection();
+                    return enableSchemeChangeDetection();
                 }
             });
         });
@@ -417,7 +434,7 @@ function enableSchemeChangeDetection() {
     if (DEBUG_MODE)
         console.log("automaticDark DEBUG: Start enableSchemeChangeDetection");
 
-    browser.storage.local.get(CHANGE_MODE_KEY)
+    return browser.storage.local.get(CHANGE_MODE_KEY)
         .then((obj) => {
             let mode = obj[CHANGE_MODE_KEY].mode;
 
@@ -431,7 +448,7 @@ function enableSchemeChangeDetection() {
                 // Without the reset, a stale overlay (e.g. last night's dark
                 // colors) gets re-applied over the newly enabled theme and masks
                 // it indefinitely, even though management reports the right theme.
-                browser.theme.reset()
+                return browser.theme.reset()
                     .then(() => browser.theme.getCurrent())
                     .then((current_theme) => {
                         if (DEBUG_MODE)
@@ -463,7 +480,7 @@ function enableSchemeChangeDetection() {
                 if (DEBUG_MODE)
                     console.log("automaticDark DEBUG: enableSchemeChangeDetection - Mode is set to: " + mode + ". Reset theme to default.");
 
-                browser.theme.reset().then(() => {
+                return browser.theme.reset().then(() => {
                     if (DEBUG_MODE)
                         console.log("automaticDark DEBUG: enableSchemeChangeDetection - Reset current theme.");
                     detect_scheme_change_block = false;

--- a/js/options.js
+++ b/js/options.js
@@ -249,7 +249,7 @@ automaticSuntimesRadio.addEventListener("input", function(event) {
                     onError(error);
                     locationWarning.style.display = "inline";
                     getChangeMode(); // In error, change radio buttons (and settings) back to the way they were, based on storage.
-                    changeThemeBasedOnChangeMode("location-theme");
+                    queueThemeSwitch(() => changeThemeBasedOnChangeMode("location-theme"));
                 });
     }
 });
@@ -259,7 +259,7 @@ manualSuntimesRadio.addEventListener("input", function(event) {
         browser.storage.local.set({[CHANGE_MODE_KEY]: {mode: "manual-suntimes"}});
         sunriseInput.disabled = false;
         sunsetInput.disabled = false;
-        changeThemeBasedOnChangeMode("manual-suntimes").then(changeLogo);
+        queueThemeSwitch(() => changeThemeBasedOnChangeMode("manual-suntimes")).then(changeLogo);
     }
 });
 
@@ -274,7 +274,7 @@ sysThemeRadio.addEventListener("input", function(event) {
         browser.storage.local.set({[CHANGE_MODE_KEY]: {mode: "system-theme"}});
         sunriseInput.disabled = true;
         sunsetInput.disabled = true;
-        changeThemeBasedOnChangeMode("system-theme").then(changeLogo);
+        queueThemeSwitch(() => changeThemeBasedOnChangeMode("system-theme")).then(changeLogo);
     }
 });
 
@@ -314,7 +314,7 @@ debugModeBox.addEventListener("input", function(event) {
 sunriseInput.addEventListener("input", function(event) {
     browser.storage.local.set({[SUNRISE_TIME_KEY]: {time: sunriseInput.value}})
         .then(() => {
-            checkTime().then(changeLogo);
+            queueThemeSwitch(checkTime).then(changeLogo);
             return browser.storage.local.get(CHECK_TIME_STARTUP_ONLY_KEY)
         }, onError)
         .then((obj) => {
@@ -329,7 +329,7 @@ sunriseInput.addEventListener("input", function(event) {
 sunsetInput.addEventListener("input", function(event) {
     browser.storage.local.set({[SUNSET_TIME_KEY]: {time: sunsetInput.value}})
         .then(() => {
-            checkTime().then(changeLogo);
+            queueThemeSwitch(checkTime).then(changeLogo);
             return browser.storage.local.get(CHECK_TIME_STARTUP_ONLY_KEY);
         }, onError)
         .then((obj) => {
@@ -347,7 +347,7 @@ daytimeThemeList.addEventListener('change', function(event) {
             return browser.storage.local.get([CHECK_TIME_STARTUP_ONLY_KEY, CHANGE_MODE_KEY]);
         }, onError)
         .then((obj) => {
-            changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode);
+            queueThemeSwitch(() => changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode));
         }, onError);
     }
 );
@@ -360,7 +360,7 @@ nighttimeThemeList.addEventListener('change', function(event) {
             return browser.storage.local.get([CHECK_TIME_STARTUP_ONLY_KEY, CHANGE_MODE_KEY]);
         }, onError)
         .then((obj) => {
-            changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode);
+            queueThemeSwitch(() => changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode));
         }, onError);
     }
 );

--- a/js/options.js
+++ b/js/options.js
@@ -278,7 +278,8 @@ sysThemeRadio.addEventListener("input", function(event) {
     }
 });
 
-// Enable/disable the check on startup-only flag.
+// Save the startup-only flag and stop or resume scheduled theme
+// switching to match.
 checkStartupBox.addEventListener("input", function(event) {
     if (checkStartupBox.checked) {
         browser.storage.local.set({[CHECK_TIME_STARTUP_ONLY_KEY]: {check: true}});
@@ -295,6 +296,17 @@ checkStartupBox.addEventListener("input", function(event) {
         browser.storage.local.set({[CHECK_TIME_STARTUP_ONLY_KEY]: {check: false}});
         createAlarm(SUNRISE_TIME_KEY, NEXT_SUNRISE_ALARM_NAME, 60 * 24);
         createAlarm(SUNSET_TIME_KEY, NEXT_SUNSET_ALARM_NAME, 60 * 24);
+        // If the background page started with this flag on, it skipped
+        // registering its scheme-change listeners, and this page cannot
+        // register them for it. Its alarm listener IS registered, so the
+        // poll alarm restores theme switching without a restart.
+        browser.alarms.create(SYSTEM_THEME_POLL_ALARM_NAME, {periodInMinutes: 1});
+        // Switch right away in case the correct theme changed while
+        // switching was off.
+        browser.storage.local.get(CHANGE_MODE_KEY)
+            .then((obj) => {
+                queueThemeSwitch(() => changeThemeBasedOnChangeMode(obj[CHANGE_MODE_KEY].mode));
+            }, onError);
         startupOnlyMessage.style.display = "none";
     }
 });

--- a/js/utils.js
+++ b/js/utils.js
@@ -73,7 +73,8 @@ function setStorage(obj, overrideDefault = false) {
             if (overrideDefault || isEmpty(items)) {
                 return browser.storage.local.set(obj)
                     .then((obj) => {
-                        console.log(obj);
+                        if (DEBUG_MODE)
+                            console.log(obj);
                     }, onError);
             }
         }, onError);

--- a/js/utils.js
+++ b/js/utils.js
@@ -50,34 +50,21 @@ function addLeadZero (num){
 }
 
 // Helper:
-// Set storage only if overrideDefault is true or
-// the managed storage is empty.
+// Set each key in storage only if overrideDefault is true or
+// that key has never been set before.
 function setStorage(obj, overrideDefault = false) {
     if (DEBUG_MODE)
         console.log("automaticDark DEBUG: Start setStorage");
 
-    for (let item in obj) {
-        browser.storage.local.get(item)
+    return Promise.all(Object.keys(obj).map((item) => {
+        return browser.storage.local.get(item)
             .then((fetchedItem) => {
                 if (overrideDefault || isEmpty(fetchedItem)) {
-                    return browser.storage.local.set(obj)
-                        .then((obj) => {}, onError);
-                    }
+                    return browser.storage.local.set({[item]: obj[item]})
+                        .then(() => {}, onError);
+                }
             }, onError);
-    }
-
-    return browser.storage.local.get(Object.keys(obj))
-        .then((items) => {
-            // Only set storage if a value is not already set,
-            // or if it is already empty.
-            if (overrideDefault || isEmpty(items)) {
-                return browser.storage.local.set(obj)
-                    .then((obj) => {
-                        if (DEBUG_MODE)
-                            console.log(obj);
-                    }, onError);
-            }
-        }, onError);
+    }));
 }
 
 // Helper: Get all active alarms.


### PR DESCRIPTION
This PR aims to fix a few bugs associated with system-theme mode switching and sunrise-sunset time switching (both manual and automatic). As discussed, I've kept everything in this one PR (may be easiest to review each commit separately).

This was tested on MacOS, Firefox Developer Edition 153.0b11.

### Bugs fixed

- Theme changes in system-theme mode could skip for multiple reasons (and potentially enter a non-functional state until user intervention):
  - If the computer woke after sleep and the theme needed changing, the theme change event may not be delivered (previously the focus listener would catch this on next click; now the 1-minute poll catches it without one)
  - Same scenario, but the focus listener would fire but get trapped on the stale theme copy - **this could not correct itself**
  - Enabling system-theme mode while the theme was already correct could skip the theme copy process entirely - **this could not correct itself**
  - Custom themes without a `properties` block crashed the theme copy workaround, so system-theme mode would not work from a fresh install - **this could not correct itself**
  - Right after installing or updating, doubled listeners could race and drop Firefox to the plain default theme
- Sunrise/sunset alarms could crash but get saved by the focus listener, now they don't crash (undeclared variables)
- Fixed crashes when entering debug mode
- Prevent settings storage writes unless changed
- Two theme switches running at the same time could interleave and strip the applied theme (dropping Firefox to the plain default theme) - switches are now queued one at a time, in the background page and in the settings page
- The "enabled" theme and the painted theme can disagree: reloading/updating the extension repaints the default theme, and theme.reset() does the same (bug 1415267). This change now detects the mismatch and forces a real repaint
- "Change only on start-up and setup" didn't switch the theme at startup - with the box ticked, the startup switch was skipped
- Unticking "change only on start-up" required a browser restart - switching now resumes straight away
- setStorage() could silently reset unrelated settings back to defaults whenever the saved bundle contained any new key
- Small thing - removed a dead alarm branch

### Testing done

- OS appearance flipped both ways via System Settings → theme followed instantly in both directions (change-event path)
- Change event suppressed, then OS flipped → the 1-minute poll corrected it in both directions with no interaction
- macOS set to auto-switch appearance, computer slept through the switch → v1.4.1 wakes stuck on the old theme and clicking doesn't fix it; on this branch the correct theme was already applied before the lid was fully open
- sunrise/sunset mode → set the OS to match the current theme → enable system-theme mode → flip the OS. On v1.4.1 no theme switch would happen; on this branch the workaround is applied immediately and subsequent flips follow
- reloaded the extension mid-session → v1.4.1 stuck on the default theme until manually re-picking one; on this branch the right theme is repainted at startup
- "change only on start-up" ticked + restart → switches once to the correct theme
- unticked "change only on start-up", then flipped the OS → corrects within a minute
- spammed mode/theme changes in the settings page → nothing stripped the theme

### Known issues remaining

- Firefox's built-in Light/Dark themes declare no colors, so the color-scheme workaround is skipped for them and a lost paint can't be detected for them either - system-theme mode with the built-ins as day/night themes still misses OS changes **(this shouldn't matter too much as you may as well just use the "System Theme - Auto" Firefox theme instead of this)**
- After unticking "change only on start-up" (without a restart), OS flips are picked up by the 1-minute poll rather than instantly - the instantaneous listeners can only be registered at browser startup
- The background page and settings page each queue their own switches, but the two pages can still overlap each other; if that ever strips the theme, the repaint fix should correct it within a minute
- overrideContentColorScheme gets set to "system", but MDN documents the valid values as "light"/"dark"/"auto" - left as-is, flagging it in case it's silently failing


Can put up another PR for these as well in future.