### PR TITLE
Substitute "auto" system theme for built in Light/Dark

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -374,25 +374,53 @@ function checkSysTheme() {
     }
 }
 
+// The built-in Light/Dark themes declare a color scheme which overrides the
+// browser's OS light/dark signal — once one is enabled the OS can no longer
+// be sensed and switching stops. In system-theme mode, the "System theme — auto" theme
+// paints the same under the OS side the slot is enabled for (identically on
+// Mac/Windows; on Linux it follows the system/GTK colors) and leaves the signal alone,
+// so enable it in their place. Skip when the same theme fills both slots
+// (the user wants that scheme permanently) or when the theme opposes its slot
+// (e.g. built-in Dark as the daytime theme) — auto would visibly repaint those.
+function substituteBuiltInTheme(themeId, themeKey) {
+    let aligned =
+        (themeKey === DAYTIME_THEME_KEY && themeId === "firefox-compact-light@mozilla.org")
+        || (themeKey === NIGHTTIME_THEME_KEY && themeId === "firefox-compact-dark@mozilla.org");
+    if (!aligned) {
+        return Promise.resolve(themeId);
+    }
+    return browser.storage.local.get([CHANGE_MODE_KEY, DAYTIME_THEME_KEY, NIGHTTIME_THEME_KEY])
+        .then((obj) => {
+            if (obj[CHANGE_MODE_KEY].mode === "system-theme"
+                && obj[DAYTIME_THEME_KEY] && obj[NIGHTTIME_THEME_KEY]
+                && obj[DAYTIME_THEME_KEY].themeId !== obj[NIGHTTIME_THEME_KEY].themeId) {
+                logDebug("substituteBuiltInTheme - " + themeId + " pins the OS scheme. Enabling System theme (auto) instead.");
+                return "default-theme@mozilla.org";
+            }
+            return themeId;
+        });
+}
+
 // Parse the object given and enable the theme.if it is not
 // already enabled.
 function enableTheme(theme, themeKey) {
     logDebug("Start enableTheme");
 
     theme = theme[themeKey];
-    return browser.management.get(theme.themeId)
-        .then((extInfo) => {
-            if (!extInfo.enabled) {
-                logDebug("100 enableTheme - Enabled theme " + theme.themeId);
-                detect_scheme_change_block = true; // Temporarily disables detection of color scheme change
-                return browser.management.setEnabled(theme.themeId, true).then(enableSchemeChangeDetection,
-                    (err) => { detect_scheme_change_block = false; onError(err); });
-            }
-            else {
-                logDebug("100 enableTheme - " + theme.themeId + " is already enabled.");
-                return reapplyColorSchemeFix(theme.themeId);
-            }
-        }, onError);
+    return substituteBuiltInTheme(theme.themeId, themeKey)
+        .then((themeId) => browser.management.get(themeId)
+            .then((extInfo) => {
+                if (!extInfo.enabled) {
+                    logDebug("100 enableTheme - Enabled theme " + themeId);
+                    detect_scheme_change_block = true; // Temporarily disables detection of color scheme change
+                    return browser.management.setEnabled(themeId, true).then(enableSchemeChangeDetection,
+                        (err) => { detect_scheme_change_block = false; onError(err); });
+                }
+                else {
+                    logDebug("100 enableTheme - " + themeId + " is already enabled.");
+                    return reapplyColorSchemeFix(themeId);
+                }
+            }, onError));
 }
 
 // Built-in themes report no colors from theme.getCurrent(), so for them a
@@ -426,8 +454,8 @@ function reapplyColorSchemeFix(themeId) {
                     // attempt worked; allow future repaints again.
                     repaint_attempted_theme = null;
                     if (!current_theme.properties || current_theme.properties.color_scheme !== "system") {
-                    return enableSchemeChangeDetection();
-                }
+                        return enableSchemeChangeDetection();
+                    }
                     return;
                 }
                 // management can report the theme as enabled while the default


### PR DESCRIPTION
Follow-up to #72 - this fixes the first item under its "Known issues remaining": system-theme mode with the built-in Light/Dark themes as day/night themes misses OS changes.

Tested on MacOS, Firefox Developer Edition.

### Important note

**This affects Linux users differently than Windows/Mac. On Windows/Mac, "System theme - auto" should show the default Firefox colours for those themes, but on Linux it'll show the GTK theme colours. Read below to see why this is relevant.**

### The bug

- In system-theme mode, picking built-in Light as the daytime theme (or built-in Dark as nighttime) kills switching: once it's enabled, the theme never changes again.
- The addon's only OS sensor is `matchMedia('(prefers-color-scheme: dark)')`, and since Firefox 95 that reflects the active theme's declared scheme, not the OS - so built-in Light pins it to "light" and the addon thinks it's daytime forever.
- The existing color-scheme repaint workaround can't save the built-ins: Firefox picks themed vs built-in rendering off the theme's *id*, not its contents ([`LightweightThemeConsumer.sys.mjs`](https://searchfox.org/mozilla-central/source/toolkit/modules/LightweightThemeConsumer.sys.mjs)), so any `theme.update()` from an extension visibly changes how they render. This was checked in the Firefox source - no overlay matches a built-in.
- What I saw in practice was the light theme not matching the built-in light theme, it had slightly different colouring and a black border around the tabs whereas the built-in didn't.

### The fix

This PR automatically enables the "System theme - auto" in place of the built-in Light/Dark themes, with a new `substituteBuiltInTheme()` step in `enableTheme()`:

- Built-in Light in the day slot (or built-in Dark in the night slot), system-theme mode, and the two slots hold different themes → enable "System theme - auto" instead.
- Safe because the day slot is only ever on screen while the OS is light, and Auto paints exactly what built-in Light would then - since Firefox 146 the built-ins literally *are* the default theme with a pinned scheme ([manifests](https://searchfox.org/mozilla-central/source/browser/themes/addons/light/manifest.json) declare only `color_scheme`, [Bugzilla 1993056](https://bugzilla.mozilla.org/show_bug.cgi?id=1993056)). Same logic for night/Dark.
- Auto never pins the sensor, so switching keeps working, and the 1-minute poll heals any stuck state as usual.

Deliberately skipped, because substituting would visibly change the look:

- Inverted setups (built-in Dark as the *daytime* theme) - Auto would paint light where the user asked for dark. Behaviour unchanged; the AMO copies of Light/Dark remain the workaround there.
- Same built-in in both slots - the user wants that scheme permanently, so a pinned sensor is harmless (and a one-sided swap would oscillate).

### Cosmetic notes

- about:addons shows "System theme - auto" as the enabled theme while substituted.
- Linux: Auto follows the GTK/system colors while the built-ins use Firefox's fixed palette, so the swap can be visibly different with a custom GTK theme. Same for Windows with the opt-in Mica/accent-color prefs. Mac/Windows at default settings: pixel-identical.

### Testing done

- macOS, built-in Light as day + built-in Dark as night → flipped the OS both ways, switches followed correctly
- side-by-side: built-in Light vs Auto in light mode - identical
- 8 behavior tests against a fake `browser` (both substitutions, all three skip conditions, missing slot, already-enabled no-op, colorful-theme repaint path untouched) - can put the harness up separately if useful
